### PR TITLE
Simpler job insertion API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,31 @@ client.put_job(json.dumps({"foo": "bar"}), delay=30)
 
 This will create a job with a 30-second delay on it. Note that the data for a job must be UTF-8 encodable.
 
+#### Creating Jobs in Specific Tubes
+
+Beanstalk has a notion of `tube`s (which is to say, named queues). There are several ways to put a
+job into a specific tube using pystalk:
+
+```lang=python
+#!/usr/bin/python
+
+from pystalk import BeanstalkClient
+
+client = BeanstalkClient('10.0.0.1', 11300)
+
+# method 1, matches the upstream protocol
+client.use("some_tube")
+client.put_job("some message")
+
+# method 2, using an external guard object like you would in C++ or Rust
+with client.using("some_tube") as inserter:
+    inserter.put_job("some message")
+
+
+# method 3
+client.put_job_into("some_tube", "some message")
+```
+
 ### Consuming All Available Jobs
 
 The following script will walk through all currently-READY jobs and then exit:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PyYAML>=3.0
+attrs>=16

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -158,3 +158,15 @@ def test_restore_after_disconnect(beanstalk_client, tube_name):
     assert beanstalk_client.stats_tube(tube_name)['current-jobs-ready'] == 1
     j = beanstalk_client.reserve_job(0)
     assert j.job_data == b'test_job'
+
+
+def test_using(beanstalk_client, tube_name):
+    beanstalk_client.use('default')
+    with beanstalk_client.using(tube_name) as inserter:
+        inserter.put_job(b'test_job')
+    assert beanstalk_client.stats_tube(tube_name)['current-jobs-ready'] == 1
+
+
+def test_put_job_into(beanstalk_client, tube_name):
+    beanstalk_client.put_job_into(tube_name, 'some_job')
+    assert beanstalk_client.stats_tube(tube_name)['current-jobs-ready'] == 1


### PR DESCRIPTION
This PR actually (somewhat unfairly) contains two diffs:

   - the first one fixes behavior so that `USE`d and `WATCH`ed tubes are re-established after a disconnect/reconnect
   - the second one adds some convenience methods to insert jobs into specific tubes and was requested by @att14 