### PR TITLE
add ProductionPool; drop support for Python 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pythonversion: ['3.6', '3.7', '3.8', '3.9', 'pypy-3.6']
+        pythonversion: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.6']
     steps:
       - uses: actions/checkout@v2
       - name: cache beanstalkd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pythonversion: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.6']
+        pythonversion: ['3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - name: cache beanstalkd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,5 @@ jobs:
         run: pytest --cov=pystalk/ --cov-report=term-missing --cov-fail-under=60 tests/
         env:
           BEANSTALKD_PATH: ~/beanstalks/beanstalkd
+      - name: check mypy
+        run: mypy pystalk/ tests/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ htmlcov
 __pycache__
 
 .DS_Store
+/build
+/dist

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project was initially created for [beancmd](https://github.com/EasyPost/bea
 
 ## Requirements / Installing
 
-This software works with Python 2.7, and 3.5+.
+This software works with Python 3.6+.
 
 It does not support any asynchronous event loops and has not been tested with gevent. It's designed for simple,
 synchronous use.
@@ -78,7 +78,25 @@ for job in client.reserve_iter():
 
 Note that, even though we require that job data be UTF-8 encodeable in the `put_job` method, we do not decode for you -- the job data that comes out is a byte-string in Python 3.5. You should call `.decode("utf-8")` on it if you want to get the input data back out. If you would like that behavior, pass `auto_decode=True` to the `BeanstalkClient` constructor; note that this might make it difficult for you to consume data injected by other systems which don't assume UTF-8.
 
-### Multiple Job Servers
+### Producing into Multiple Job Servers
+
+This library includes the `ProductionPool` class, which will insert jobs into beanstalk servers, rotating between them
+when an error occurs. Example usage:
+
+```python
+from pystalk import BeanstalkClient, ProductionPool
+
+pool = ProductionPool.from_uris(
+    ['beanstalkd://10.0.0.1:10300', 'beanstalkd://10.0.0.2:10300'],
+    socket_timeout=10
+)
+pool.put_job_into('some tube', 'some job')
+```
+
+The Pool **only** supports the `put_job` and `put_job_into` methods and makes no fairness guarantees; you should not use
+it for consumption.
+
+### Consuming From Multiple Job Servers
 
 The following will reserve jobs from a group of Beanstalk servers, fairly rotating between them.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ This project was initially created for [beancmd](https://github.com/EasyPost/bea
 [![CI](https://github.com/EasyPost/pystalk/workflows/CI/badge.svg)](https://github.com/EasyPost/pystalk/actions?query=workflow%3ACI)
 [![ReadTheDocs](https://readthedocs.org/projects/pip/badge/?version=latest)](http://pystalk.readthedocs.io/en/latest/)
 
+Note that _none_ of the objects in this package are inherently synchronized (thread-safe), and if you are going to use
+them from multiple threads, you should always protect them with a mutex. Clients are also not fork-safe, and should be
+initialized after any forking.
+
 ## Requirements / Installing
 
 This software works with Python 3.6+. It should work PyPy3 but has not been tested extensively.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-**`pystalk`** is an extremely simple client for [beanstalkd](http://kr.github.io/beanstalkd/). It is
-compatible with both Python 2 and Python 3.
+**`pystalk`** is an extremely simple Python client for [beanstalkd](http://kr.github.io/beanstalkd/).
 
 This project was initially created for [beancmd](https://github.com/EasyPost/beancmd). You may also be interested in that tool!
 
@@ -8,7 +7,7 @@ This project was initially created for [beancmd](https://github.com/EasyPost/bea
 
 ## Requirements / Installing
 
-This software works with Python 3.6+.
+This software works with Python 3.6+. It should work PyPy3 but has not been tested extensively.
 
 It does not support any asynchronous event loops and has not been tested with gevent. It's designed for simple,
 synchronous use.

--- a/docs/source/CHANGES.rst
+++ b/docs/source/CHANGES.rst
@@ -3,6 +3,13 @@ pystalk ChangeLog
 #################
 
 =====
+NEXT
+======
+* Drop support for Python < 3.6
+* Add `pystalk.pool.ProductionPool`
+* Add some `typing` annotations
+
+=====
 0.6.1
 =====
 * More emphatically remove `tests` from distributed packages

--- a/pystalk/__init__.py
+++ b/pystalk/__init__.py
@@ -1,8 +1,9 @@
 from .client import BeanstalkClient, BeanstalkError
+from .pool import ProductionPool
 
 version_info = (0, 6, 1)
 __version__ = '.'.join(str(s) for s in version_info)
 __author__ = 'EasyPost <oss@easypost.com>'
 
 
-__all__ = ['BeanstalkClient', 'BeanstalkError']
+__all__ = ['BeanstalkClient', 'BeanstalkError', 'ProductionPool']

--- a/pystalk/client.py
+++ b/pystalk/client.py
@@ -83,7 +83,8 @@ class BeanstalkClient(object):
          Setting socket timeout to a value lower than the value you pass to blocking functions like
          :func:`reserve_job()` will cause errors!
     """
-    def __init__(self, host: str, port: int = 11300, socket_timeout: Optional[float] = None, auto_decode: bool=False):
+    def __init__(self, host: str, port: int = 11300, socket_timeout: Optional[float] = None,
+                 auto_decode: bool = False):
         """Construct a synchronous Beanstalk Client. Does not connect!"""
         self.host = host
         self.port = port

--- a/pystalk/pool.py
+++ b/pystalk/pool.py
@@ -61,10 +61,10 @@ class ProductionPool(object):
         if not clients:
             raise ValueError('Must pass at least one BeanstalkClient')
         self._current_client_index = 0
-        clients = [ClientRecord(c) for c in clients]
+        client_records = [ClientRecord(c) for c in clients]
         if shuffle:
-            random.shuffle(clients)
-        self._clients = deque(clients)
+            random.shuffle(client_records)
+        self._clients = deque(client_records)
         self.current_tube: Optional[str] = None
         self.round_robin = round_robin
         self.backoff_time = backoff_time

--- a/pystalk/pool.py
+++ b/pystalk/pool.py
@@ -1,0 +1,168 @@
+from typing import List, Optional, Union
+import time
+import random
+import socket
+import logging
+
+from .client import BeanstalkClient, BeanstalkError
+
+
+RETRIABLE_ERRORS = ('INTERNAL_ERROR', 'OUT_OF_MEMORY')
+
+
+def _get_time():
+    return time.monotonic()
+
+
+class NoMoreClients(Exception):
+    def __str__(self):
+        return "No clients can process requests at this time"
+
+
+class ProductionPool(object):
+    """A pool for producing jobs into a list of beanstalk servers. When an error occurs, job insertion
+    will be re-attempted on the next server in the pool.
+
+    :param clients: List of beanstalk client instances to use
+    :param rotate_time: Number of seconds after which connections will be rotated (for load-balancing). Set to None
+        to disable rotation
+    :param backoff_time: Number of seconds after an error before a server will be reused
+    :param shuffle: Randomly shuffle clients at initialization
+
+    All clients should have a socket timeout set or else some errors will not be detected.
+
+    NOTE: This will give you at-least-once deliverability (presuming at least one server is up), but can *easily*
+    result in jobs being issued multiple times. Only use this functionality with idempotent jobs.
+
+    This method of pooling is only suitable for use when *producing* jobs. For *consuming* jobs from a cluster of
+    beanstalkd servers, consider the `pystalkworker` project.
+    """
+    def __init__(self, clients: List[BeanstalkClient], rotate_time: Optional[float] = 600.0,
+                 backoff_time: float = 10.0, shuffle: bool = True):
+        if not clients:
+            raise ValueError('Must pass at least one BeanstalkClient')
+        self._current_client_index = 0
+        self._last_rotate_time = _get_time()
+        self._clients = clients[:]
+        if shuffle:
+            random.shuffle(self._clients)
+        self._last_failure = [None for _ in clients]
+        self.current_tube: Optional[str] = None
+        self.rotate_time = rotate_time
+        self.backoff_time = backoff_time
+        self.log = logging.getLogger('pystalk.ProductionPool')
+
+    @classmethod
+    def from_uris(cls, uris: List[str], socket_timeout: float = None, auto_decode: bool = False,
+                  rotate_time: Optional[float] = 600.0, backoff_time: float = 10.0, shuffle: bool = True):
+        """Construct a pool from a list of URIs. See `pystalk.client.Client.from_uri` for more information.
+
+        :param uris: A list of URIs
+        :param socket_timeout: Socket timeout to set on all constructed clients
+        :param auto_decode: Whether bodies should be bytes (False) or strings (True)
+        """
+        return cls(
+            clients=[BeanstalkClient.from_uri(uri, socket_timeout=socket_timeout, auto_decode=auto_decode)
+                     for uri in uris],
+            rotate_time=rotate_time,
+            backoff_time=backoff_time,
+            shuffle=shuffle
+        )
+
+    def use(self, tube: str):
+        """Start producing jobs into the given tube.
+
+        :param tube: Name of the tube to USE
+
+        Subsequent calls to :func:`put_job` insert jobs into this tube.
+        """
+        self.current_tube = tube
+
+    def _get_client(self):
+        now = _get_time()
+        start = 0
+        if self.rotate_time:
+            if now - self._last_rotate_time > self.rotate_time:
+                start = 1
+                self._last_rotate_time = now
+        for index_offset in range(start, len(self._clients)):
+            index = (self._current_client_index + index_offset) % len(self._clients)
+            if self._last_failure[index] is None or now - self._last_failure[index] > self.backoff_time:
+                self._current_client_index = index
+                client = self._clients[index]
+                if client.current_tube != self.current_tube:
+                    client.use(self.current_tube)
+                return index, client
+        self.log.error('All clients are failed! %r', self._last_failure)
+        raise NoMoreClients()
+
+    def _mark_client_failed(self, client_index: int):
+        self._last_failure[client_index] = _get_time()
+
+    def _attempt_on_all_clients(self, thunk):
+        while True:
+            try:
+                index, client = self._get_client()
+                return thunk(client)
+            except BeanstalkError as e:
+                if e.message in RETRIABLE_ERRORS:
+                    self.log.warning('error on server %r (%d): %r', client, index, e)
+                    self._mark_client_failed(index)
+                else:
+                    raise
+            except (socket.error) as e:
+                self.log.warning('error on server %r (%d): %r', client, index, e)
+                self._mark_client_failed(index)
+
+    def put_job(self, data: Union[str, bytes], pri: int = 65536, delay: int = 0, ttr: int = 120):
+        """Insert a new job into whatever queue is currently USEd
+
+        :param data: Job body
+        :type data: Text (either str which will be encoded as utf-8, or bytes which are already utf-8
+        :param pri: Priority for the job
+        :type pri: int
+        :param delay: Delay in seconds before the job should be placed on the ready queue
+        :type delay: int
+        :param ttr: Time to reserve (how long a worker may work on this job before we assume the worker is blocked
+            and give the job to another worker
+        :type ttr: int
+
+        .. seealso::
+
+           :func:`put_job_into()`
+              Put a job into a specific tube
+
+           :func:`using()`
+              Insert a job using an external guard
+        """
+        return self._attempt_on_all_clients(
+            lambda client: client.put_job(data=data, pri=pri, delay=delay, ttr=120)
+        )
+
+    def put_job_into(self, tube_name: str, data: Union[str, bytes], pri: int = 65536,
+                     delay: int = 0, ttr: int = 120):
+        """Insert a new job into a specific queue. Wrapper around :func:`put_job`.
+
+        :param tube_name: Tube name
+        :type tube_name: str
+        :param data: Job body
+        :type data: Text (either str which will be encoded as utf-8, or bytes which are already utf-8
+        :param pri: Priority for the job
+        :type pri: int
+        :param delay: Delay in seconds before the job should be placed on the ready queue
+        :type delay: int
+        :param ttr: Time to reserve (how long a worker may work on this job before we assume the worker is blocked
+            and give the job to another worker
+        :type ttr: int
+
+        .. seealso::
+
+           :func:`put_job()`
+              Put a job into whatever the current tube is
+
+           :func:`using()`
+              Insert a job using an external guard
+        """
+        return self._attempt_on_all_clients(
+            lambda client: client.put_job_into(tube_name=tube_name, data=data, pri=pri, delay=delay, ttr=120)
+        )

--- a/pystalk/pool.py
+++ b/pystalk/pool.py
@@ -46,7 +46,7 @@ class ProductionPool(object):
     :param round_robin: If true, every insertion will go to a different server in the pool. If false,
         the server will only be changed when an exception occurs.
     :param backoff_time: Number of seconds after an error before a server will be reused
-    :param shuffle: Randomly shuffle clients at initialization
+    :param initial_shuffle: Randomly shuffle clients at initialization
 
     All clients should have a socket timeout set or else some errors will not be detected.
 
@@ -57,12 +57,11 @@ class ProductionPool(object):
     beanstalkd servers, consider the `pystalkworker` project.
     """
     def __init__(self, clients: List[BeanstalkClient], round_robin: bool = True,
-                 backoff_time: float = 10.0, shuffle: bool = True):
+                 backoff_time: float = 10.0, initial_shuffle: bool = True):
         if not clients:
             raise ValueError('Must pass at least one BeanstalkClient')
-        self._current_client_index = 0
         client_records = [ClientRecord(c) for c in clients]
-        if shuffle:
+        if initial_shuffle:
             random.shuffle(client_records)
         self._clients = deque(client_records)
         self.current_tube: Optional[str] = None
@@ -72,7 +71,7 @@ class ProductionPool(object):
 
     @classmethod
     def from_uris(cls, uris: List[str], socket_timeout: float = None, auto_decode: bool = False,
-                  round_robin: bool = True, backoff_time: float = 10.0, shuffle: bool = True):
+                  round_robin: bool = True, backoff_time: float = 10.0, initial_shuffle: bool = True):
         """Construct a pool from a list of URIs. See `pystalk.client.Client.from_uri` for more information.
 
         :param uris: A list of URIs
@@ -84,7 +83,7 @@ class ProductionPool(object):
                      for uri in uris],
             round_robin=round_robin,
             backoff_time=backoff_time,
-            shuffle=shuffle
+            initial_shuffle=initial_shuffle
         )
 
     def use(self, tube: str):

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,5 @@
-pytest==3.5.*
-pytest_cov==2.5.*
+pytest==7.1.*
+pytest-cov==3.0.*
+pytest-mock==3.8.*
 mock
 flake8

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,3 +3,6 @@ pytest-cov==3.0.*
 pytest-mock==3.8.*
 mock
 flake8
+mypy==0.971
+types-PyYAML
+types-six

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,6 @@
-pytest==7.1.*
-pytest-cov==3.0.*
-pytest-mock==3.8.*
+pytest==7.*
+pytest-cov==3.*
+pytest-mock==3.*
 mock
 flake8
 mypy==0.971

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 PyYAML>=3.0
-attrs>=17.4
+attrs>=19.2
 six
+mypy==0.971
+types-PyYAML
+types-six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
 PyYAML>=3.0
 attrs>=19.2
 six
-mypy==0.971
-types-PyYAML
-types-six

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Intended Audience :: System Administrators",
         "Operating System :: OS Independent",
         "Topic :: Database",

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import sys
 import os.path
 from setuptools import setup, find_packages
 
@@ -10,12 +9,7 @@ with open(os.path.join(project_root, 'requirements.txt'), 'r') as f:
         install_requires.append(line.rstrip())
 
 
-read_kwargs = {}
-
-if sys.version_info > (3, 0):
-    read_kwargs['encoding'] = 'utf-8'
-
-with open(os.path.join(project_root, 'README.md'), **read_kwargs) as f:
+with open(os.path.join(project_root, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
@@ -31,7 +25,7 @@ setup(
     license="ISC",
     install_requires=install_requires,
     packages=find_packages(exclude=['tests', 'tests.*']),
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4',
+    python_requires='>=3.6, <4',
     project_urls={
         'CI': 'https://travis-ci.com/EasyPost/pystalk',
     },
@@ -39,8 +33,6 @@ setup(
         "Development Status :: 4 - Beta",
         "Environment :: Console",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,7 +11,7 @@ import pytest
 import pystalk
 
 
-@pytest.yield_fixture(scope='session')
+@pytest.fixture(scope='session')
 def tmpdir_session():
     d = tempfile.mkdtemp()
     try:
@@ -20,7 +20,7 @@ def tmpdir_session():
         shutil.rmtree(d)
 
 
-@pytest.yield_fixture(scope='session')
+@pytest.fixture(scope='session')
 def beanstalkd(tmpdir_session):
     wal_dir = os.path.join(tmpdir_session, 'wal')
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/tests/integration/test_pool.py
+++ b/tests/integration/test_pool.py
@@ -1,0 +1,52 @@
+import logging
+
+import pytest
+
+from pystalk.pool import ProductionPool, NoMoreClients
+from pystalk.client import BeanstalkError
+
+
+def test_single_server(beanstalk_client, tube_name):
+    p = ProductionPool([beanstalk_client])
+    p.put_job_into(tube_name, b'job 1')
+    beanstalk_client.watch(tube_name)
+    assert beanstalk_client.reserve_job(timeout=1).job_data == b'job 1'
+
+
+def test_single_broken_server(tube_name, mocker):
+    client = mocker.Mock()
+    client.current_tube = tube_name
+    client.put_job_into.side_effect = BeanstalkError(b'INTERNAL_ERROR')
+    p = ProductionPool([client])
+    with pytest.raises(NoMoreClients):
+        p.put_job_into(tube_name, b'job 1')
+
+
+def test_one_good_one_bad(tube_name, mocker, beanstalk_client, caplog):
+    bad_client = mocker.Mock()
+    bad_client.current_tube = tube_name
+    bad_client.put_job_into.side_effect = BeanstalkError(b'INTERNAL_ERROR')
+    p = ProductionPool([bad_client, beanstalk_client], shuffle=False, backoff_time=10)
+    # put a job; this should try the bad tube, then the good tube and succeed
+    with caplog.at_level(logging.WARNING):
+        p.put_job_into(tube_name, b'job 1')
+    assert len(caplog.records) > 0
+    beanstalk_client.watch(tube_name)
+    assert beanstalk_client.reserve_job(timeout=1).job_data == b'job 1'
+    assert bad_client.put_job_into.call_count == 1
+    # at this point, the bad tube is in backoff; confirm that it doesn't get hit again
+    caplog.clear()
+    bad_client.put_job_into.reset_mock()
+    with caplog.at_level(logging.WARNING):
+        p.put_job_into(tube_name, b'job 2')
+    assert len(caplog.records) == 0
+    assert beanstalk_client.reserve_job(timeout=1).job_data == b'job 2'
+    assert bad_client.put_job_into.call_count == 0
+
+
+def test_from_uris(beanstalkd, beanstalk_client, tube_name):
+    host, port = beanstalkd
+    p = ProductionPool.from_uris(['beanstalkd://{0}:{1}'.format(host, port)])
+    p.put_job_into(tube_name, b'job 1')
+    beanstalk_client.watch(tube_name)
+    assert beanstalk_client.reserve_job(timeout=1).job_data == b'job 1'

--- a/tests/integration/test_pool.py
+++ b/tests/integration/test_pool.py
@@ -28,7 +28,7 @@ def test_one_good_one_bad(tube_name, mocker, beanstalk_client, caplog):
     bad_client = mocker.Mock()
     bad_client.current_tube = tube_name
     bad_client.put_job_into.side_effect = BeanstalkError(b'INTERNAL_ERROR')
-    p = ProductionPool([bad_client, beanstalk_client], shuffle=False, backoff_time=10)
+    p = ProductionPool([bad_client, beanstalk_client], initial_shuffle=False, backoff_time=10)
     # put a job; this should try the bad tube, then the good tube and succeed
     with caplog.at_level(logging.WARNING):
         p.put_job_into(tube_name, b'job 1')

--- a/tests/integration/test_pool.py
+++ b/tests/integration/test_pool.py
@@ -2,6 +2,7 @@ import logging
 
 import pytest
 
+from pystalk import pool
 from pystalk.pool import ProductionPool, NoMoreClients
 from pystalk.client import BeanstalkError
 
@@ -23,6 +24,7 @@ def test_single_broken_server(tube_name, mocker):
 
 
 def test_one_good_one_bad(tube_name, mocker, beanstalk_client, caplog):
+    mock_time = mocker.patch.object(pool, '_get_time', return_value=1)
     bad_client = mocker.Mock()
     bad_client.current_tube = tube_name
     bad_client.put_job_into.side_effect = BeanstalkError(b'INTERNAL_ERROR')
@@ -39,9 +41,22 @@ def test_one_good_one_bad(tube_name, mocker, beanstalk_client, caplog):
     bad_client.put_job_into.reset_mock()
     with caplog.at_level(logging.WARNING):
         p.put_job_into(tube_name, b'job 2')
+        p.put_job_into(tube_name, b'job 3')
+        p.put_job_into(tube_name, b'job 4')
     assert len(caplog.records) == 0
-    assert beanstalk_client.reserve_job(timeout=1).job_data == b'job 2'
+    assert [j.job_data for j in beanstalk_client.reserve_iter()] == [b'job 2', b'job 3', b'job 4']
     assert bad_client.put_job_into.call_count == 0
+    # okay, now pretend backoff expired
+    mock_time.return_value = 12
+    caplog.clear()
+    bad_client.put_job_into.reset_mock()
+    with caplog.at_level(logging.WARNING):
+        p.put_job_into(tube_name, b'job 5')
+        p.put_job_into(tube_name, b'job 6')
+        p.put_job_into(tube_name, b'job 7')
+    assert len(caplog.records) == 1
+    assert [j.job_data for j in beanstalk_client.reserve_iter()] == [b'job 5', b'job 6', b'job 7']
+    assert bad_client.put_job_into.call_count == 1
 
 
 def test_from_uris(beanstalkd, beanstalk_client, tube_name):


### PR DESCRIPTION
- `ProductionPool` is an object which can be used like a Client for `put_job` but can be backed by several servers.
- Python 2 is now so old as to be difficult to test against, and has been EOL for more than 2 years. Drop it.
- Bumps `pytest` and cleans that up a bit
- Adds some mypy annotations (mostly useless)