### PR TITLE
update README.md to include client.watch call

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The following script will walk through all currently-READY jobs and then exit:
 from pystalk import BeanstalkClient
 
 client = BeanstalkClient('10.0.0.1', 11300)
+client.watch('some_tube')
 for job in client.reserve_iter():
     try:
         execute_job(job)


### PR DESCRIPTION
Change the readme so that the client watches the same tube we sent a job to earlier.

The code snippets in the README don't include a call to `client.watch`, so the watchlist remains set to the `default` tube.  Calling `client.watch` better reflects typical API usage, and allows the client to reserve the job sent earlier in the snippets so the example can run end-to-end.
